### PR TITLE
ci: automate release process with tags (Bug 1966959)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -20,13 +21,10 @@ jobs:
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine
+          pip install build
 
       - name: Build package
         run: python -m build
 
       - name: Publish to PyPI
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-        run: python -m twine upload dist/*
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,32 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: python -m twine upload dist/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.10, 3.11, 3.12]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: [3.10, 3.11, 3.12]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[code-quality,testing]
+
+      - name: Run tests
+        run: pytest
+

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -6,11 +6,21 @@ from functools import wraps
 from pathlib import Path
 from typing import Any, Optional
 
+from importlib.metadata import PackageNotFoundError, version
+
 import click
 import requests
 import tomli
 
-__version__ = "0.0.7"
+def get_version() -> str:
+    try:
+        return version("lando_cli")
+    except PackageNotFoundError:
+        # package is not installed
+        return "0.0.0"
+
+
+__version__ = get_version()
 
 DEFAULT_CONFIG_PATH = Path.home() / ".mozbuild" / "lando.toml"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [project]
 description =  "Lando Headless API Client"
-version = "0.0.7"
 authors = [
     {name = "Mozilla", email = "conduit-team@mozilla.com"},
 ]
@@ -14,12 +13,19 @@ dependencies = [
 name = "lando_cli"
 requires-python = ">=3.10"
 
+# Required for `setuptools_scm` when using only `pyproject.toml` (ie no `setup.cfg`).
+dynamic = ["version"]
+
 [project.optional-dependencies]
 code-quality = ["black", "ruff"]
 testing = [
   "pytest",
   "requests-mock"
 ]
+
+
+# Derive version number from version control.
+[tool.setuptools_scm]
 
 [project.scripts]
 lando = "lando_cli.cli:cli"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,10 @@ from lando_cli.cli import (
 def git_remote_repo(tmp_path: Path):
     """Create a temporary bare remote Git repo."""
     remote_repo = tmp_path / "remote.git"
-    subprocess.run(["git", "init", "--bare", remote_repo.as_posix()], check=True)
+    subprocess.run(
+        ["git", "init", "--bare", remote_repo.as_posix(), "--initial-branch", "main"],
+        check=True,
+    )
     yield remote_repo
 
 


### PR DESCRIPTION
Switch to using `setuptools_scm` to determine the app
version from release tags. Add a Github actions `test`
workflow to run tests on every PR and push, and a
`publish` workflow to release on pushing a tag.
