### PR TITLE
add-commits: use bytes when dealing with format-patch output (bug 1967655)

### DIFF
--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -313,7 +313,6 @@ def create_add_commit_actions(patches: list[bytes]) -> list[dict]:
             # We encode the raw bytes to BASE64, which we then need to decode to a str
             # for JSON encoding.
             "content": base64.b64encode(patch).decode("ascii"),
-            "patch_format": "git-format-patch",
         }
         for patch in patches
     ]

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -262,6 +262,9 @@ def _git_run(git_args: list[str], repo: Path, raw: bool = False):
         cwd=repo,
         **extra_run_args,
     )
+    if raw:
+        return result.stdout
+
     return result.stdout.strip()
 
 

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -1,3 +1,4 @@
+import base64
 import os
 import subprocess
 import time
@@ -307,7 +308,11 @@ def get_commit_patches(commits: list[str], repo: Path) -> list[bytes]:
 def create_add_commit_actions(patches: list[bytes]) -> list[dict]:
     """Given an ordered list of patches, create `add-commit` actions for each."""
     return [
-        {"action": "add-commit", "content": patch, "patch_format": "git-format-patch"}
+        {
+            "action": "add-commit-base64",
+            "content": base64.encodebytes(patch),
+            "patch_format": "git-format-patch",
+        }
         for patch in patches
     ]
 

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -229,17 +229,30 @@ def submit_to_lando(
     return
 
 
-def git_run(git_args: list[str], repo: Path, raw: bool = False) -> str:
+def git_run(*args, **kwargs) -> str:
     """Helper to run `git` with consistent arguments."""
+    return _git_run(*args, **kwargs)
+
+
+def git_run_bytes(*args, **kwargs) -> bytes:
+    """Helper to run `git` with consistent arguments, and return raw bytes output"""
+    kwargs["raw"] = True
+    return _git_run(*args, **kwargs)
+
+
+def _git_run(git_args: list[str], repo: Path, raw: bool = False):
+    """Helper to run `git` with consistent arguments.
+
+    If raw is True, data is returned as bytes. Otherwise, a string with normalised
+    newlines is returned.
+    """
     command = ["git", *git_args]
     extra_run_args = {}
     if not raw:
-        extra_run_args.update(
-            {
-                "encoding": "utf-8",
-                "text": True,
-            }
-        )
+        extra_run_args = {
+            "encoding": "utf-8",
+            "text": True,
+        }
     result = subprocess.run(
         command,
         stdout=subprocess.PIPE,
@@ -283,8 +296,8 @@ def get_commit_patches(commits: list[str], repo: Path) -> list[bytes]:
     """Get `git format-patch` patches for each passed commit SHA."""
     patches = []
     for idx, commit in enumerate(commits):
-        patch = git_run(
-            ["format-patch", commit, "-1", "--always", "--stdout"], repo, raw=True
+        patch = git_run_bytes(
+            ["format-patch", commit, "-1", "--always", "--stdout"], repo
         )
         patches.append(patch)
 

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -340,7 +340,7 @@ def display_add_commit_actions(
     click.echo(f"About to push {len(actions)} commits.")
 
     # Use the last patch as the tip commit
-    last_patch = actions[-1]["content"]
+    last_patch = base64.b64decode(actions[-1]["content"]).decode("utf-8")
     first_line = last_patch.splitlines()[0]
 
     if first_line.startswith("From "):

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -236,7 +236,7 @@ def git_run(*args, **kwargs) -> str:
 
 
 def git_run_bytes(*args, **kwargs) -> bytes:
-    """Helper to run `git` with consistent arguments, and return raw bytes output"""
+    """Helper to run `git` with consistent arguments, and return raw bytes output."""
     kwargs["raw"] = True
     return _git_run(*args, **kwargs)
 

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -306,7 +306,7 @@ def get_commit_patches(commits: list[str], repo: Path) -> list[bytes]:
 
 
 def create_add_commit_actions(patches: list[bytes]) -> list[dict]:
-    """Given an ordered list of patches, create `add-commit` actions for each."""
+    """Given an ordered list of patches, create `add-commit-base64` actions for each."""
     return [
         {
             "action": "add-commit-base64",

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -229,17 +229,24 @@ def submit_to_lando(
     return
 
 
-def git_run(git_args: list[str], repo: Path) -> str:
+def git_run(git_args: list[str], repo: Path, raw: bool = False) -> str:
     """Helper to run `git` with consistent arguments."""
     command = ["git", *git_args]
+    extra_run_args = {}
+    if not raw:
+        extra_run_args.update(
+            {
+                "encoding": "utf-8",
+                "text": True,
+            }
+        )
     result = subprocess.run(
         command,
-        encoding="utf-8",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        text=True,
         check=True,
         cwd=repo,
+        **extra_run_args,
     )
     return result.stdout.strip()
 
@@ -272,17 +279,19 @@ def get_new_commits(local_branch: str, base_sha: str, repo: Path) -> list[str]:
     return commits
 
 
-def get_commit_patches(commits: list[str], repo: Path) -> list[str]:
+def get_commit_patches(commits: list[str], repo: Path) -> list[bytes]:
     """Get `git format-patch` patches for each passed commit SHA."""
     patches = []
     for idx, commit in enumerate(commits):
-        patch = git_run(["format-patch", commit, "-1", "--always", "--stdout"], repo)
+        patch = git_run(
+            ["format-patch", commit, "-1", "--always", "--stdout"], repo, raw=True
+        )
         patches.append(patch)
 
     return patches
 
 
-def create_add_commit_actions(patches: list[str]) -> list[dict]:
+def create_add_commit_actions(patches: list[bytes]) -> list[dict]:
     """Given an ordered list of patches, create `add-commit` actions for each."""
     return [
         {"action": "add-commit", "content": patch, "patch_format": "git-format-patch"}

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -310,7 +310,7 @@ def create_add_commit_actions(patches: list[bytes]) -> list[dict]:
     return [
         {
             "action": "add-commit-base64",
-            "content": base64.encodebytes(patch),
+            "content": base64.b64encode(patch),
             "patch_format": "git-format-patch",
         }
         for patch in patches

--- a/lando_cli/cli.py
+++ b/lando_cli/cli.py
@@ -310,7 +310,9 @@ def create_add_commit_actions(patches: list[bytes]) -> list[dict]:
     return [
         {
             "action": "add-commit-base64",
-            "content": base64.b64encode(patch),
+            # We encode the raw bytes to BASE64, which we then need to decode to a str
+            # for JSON encoding.
+            "content": base64.b64encode(patch).decode("ascii"),
             "patch_format": "git-format-patch",
         }
         for patch in patches

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+import subprocess
+import pytest
+
+
+@pytest.fixture
+def git_remote_repo(tmp_path: Path):
+    """Create a temporary bare remote Git repo."""
+    remote_repo = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", remote_repo.as_posix(), "--initial-branch", "main"],
+        check=True,
+    )
+    yield remote_repo
+
+
+@pytest.fixture
+def git_local_repo(tmp_path: Path, git_remote_repo: Path):
+    """Create a temporary local G
+    it repo with remote set up."""
+    local_repo = tmp_path / "local"
+    local_repo.mkdir()
+
+    subprocess.run(
+        ["git", "clone", git_remote_repo.as_posix(), local_repo.as_posix()],
+        check=True,
+        cwd=local_repo,
+    )
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=local_repo)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=local_repo)
+
+    # Create an initial commit
+    (local_repo / "README.md").write_text("# Test Repo")
+    subprocess.run(["git", "add", "."], cwd=local_repo)
+    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=local_repo)
+
+    subprocess.run(["git", "push", "-u", "origin", "main:main"], cwd=local_repo)
+
+    yield local_repo
+
+
+@pytest.fixture
+def create_commit(git_local_repo: Path):
+    def commit_creator(
+        patch_content: bytes | str = b"content",
+        commit_message: str = "New commit",
+        path: Path = Path("file.txt"),
+    ):
+        if not isinstance(patch_content, bytes):
+            patch_content = patch_content.encode("utf-8")
+
+        (git_local_repo / path).write_bytes(patch_content)
+        subprocess.run(["git", "add", "."], cwd=git_local_repo)
+        subprocess.run(["git", "commit", "-m", commit_message], cwd=git_local_repo)
+
+    return commit_creator

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,4 @@
+from typing import Callable
 import pytest
 from pathlib import Path
 import subprocess
@@ -12,41 +13,6 @@ from lando_cli.cli import (
     determine_base_sha_for_push,
     get_current_branch,
 )
-
-
-@pytest.fixture
-def git_remote_repo(tmp_path: Path):
-    """Create a temporary bare remote Git repo."""
-    remote_repo = tmp_path / "remote.git"
-    subprocess.run(
-        ["git", "init", "--bare", remote_repo.as_posix(), "--initial-branch", "main"],
-        check=True,
-    )
-    yield remote_repo
-
-
-@pytest.fixture
-def git_local_repo(tmp_path: Path, git_remote_repo: Path):
-    """Create a temporary local Git repo with remote set up."""
-    local_repo = tmp_path / "local"
-    local_repo.mkdir()
-
-    subprocess.run(
-        ["git", "clone", git_remote_repo.as_posix(), local_repo.as_posix()],
-        check=True,
-        cwd=local_repo,
-    )
-    subprocess.run(["git", "config", "user.name", "Test User"], cwd=local_repo)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=local_repo)
-
-    # Create an initial commit
-    (local_repo / "README.md").write_text("# Test Repo")
-    subprocess.run(["git", "add", "."], cwd=local_repo)
-    subprocess.run(["git", "commit", "-m", "Initial commit"], cwd=local_repo)
-
-    subprocess.run(["git", "push", "-u", "origin", "main:main"], cwd=local_repo)
-
-    yield local_repo
 
 
 @pytest.mark.parametrize(
@@ -127,11 +93,9 @@ def test_get_current_branch(git_local_repo: Path):
     assert branch == "testbranch"
 
 
-def test_get_new_commits(git_local_repo: Path):
+def test_get_new_commits(git_local_repo: Path, create_commit: Callable):
     # Create a new commit
-    (git_local_repo / "file.txt").write_text("content")
-    subprocess.run(["git", "add", "."], cwd=git_local_repo)
-    subprocess.run(["git", "commit", "-m", "New commit"], cwd=git_local_repo)
+    create_commit()
 
     commits = get_new_commits("main", "origin/main", git_local_repo)
     assert len(commits) == 1
@@ -141,17 +105,16 @@ def test_get_new_commits(git_local_repo: Path):
 
 
 @pytest.mark.parametrize("patch_content", [b"patch content", b"patch\r\ncontent"])
-def test_get_commit_patches(git_local_repo: Path, patch_content: bytes):
-    commit_message = b"Patch commit"
-    (git_local_repo / "file.txt").write_bytes(patch_content)
-    subprocess.run(["git", "add", "."], cwd=git_local_repo)
-    subprocess.run(["git", "commit", "-m", commit_message], cwd=git_local_repo)
-
+def test_get_commit_patches(
+    git_local_repo: Path, create_commit: Callable, patch_content: bytes
+):
+    commit_message = "Patch commit"
+    create_commit(patch_content, commit_message)
     commits = get_new_commits("main", "origin/main", git_local_repo)
     patches = get_commit_patches(commits, git_local_repo)
 
     assert len(patches) == 1
-    assert patches[0].find(commit_message)
+    assert patches[0].find(commit_message.encode("utf-8"))
     assert patches[0].find(patch_content)
 
 
@@ -168,12 +131,12 @@ def test_detect_new_tags(git_local_repo: Path):
     assert not new_tags_after_push
 
 
-def test_detect_merge_from_current_head_true_merge(git_local_repo: Path):
+def test_detect_merge_from_current_head_true_merge(
+    git_local_repo: Path, create_commit: Callable
+):
     # Create a branch and commit
     subprocess.run(["git", "switch", "-c", "branch"], cwd=git_local_repo)
-    (git_local_repo / "branch_file.txt").write_text("branch content")
-    subprocess.run(["git", "add", "."], cwd=git_local_repo)
-    subprocess.run(["git", "commit", "-m", "Branch commit"], cwd=git_local_repo)
+    create_commit("branch content", "Branch commit")
 
     # Switch to main and merge with no-ff
     subprocess.run(["git", "switch", "main"], cwd=git_local_repo)
@@ -189,11 +152,13 @@ def test_detect_merge_from_current_head_true_merge(git_local_repo: Path):
     assert actions[0]["target"] is not None
 
 
-def test_detect_merge_from_current_head_fast_forward(git_local_repo: Path):
+def test_detect_merge_from_current_head_fast_forward(
+    git_local_repo: Path, create_commit: Callable
+):
+    commit_message = "FF commit"
+
     subprocess.run(["git", "switch", "-c", "ff-branch"], cwd=git_local_repo)
-    (git_local_repo / "ff_file.txt").write_text("ff content")
-    subprocess.run(["git", "add", "."], cwd=git_local_repo)
-    subprocess.run(["git", "commit", "-m", "FF commit"], cwd=git_local_repo)
+    create_commit("ff content", commit_message, "ff_file.txt")
 
     # Switch to main and perform fast-forward merge
     subprocess.run(["git", "switch", "main"], cwd=git_local_repo)
@@ -202,7 +167,7 @@ def test_detect_merge_from_current_head_fast_forward(git_local_repo: Path):
     actions = detect_merge_from_current_head(git_local_repo)
     assert actions is not None
     assert len(actions) == 1
-    assert actions[0]["commit_message"] == "FF commit"
+    assert actions[0]["commit_message"] == commit_message
     assert actions[0]["target"] is not None
 
 
@@ -236,13 +201,13 @@ def test_determine_base_sha_for_push_with_relbranch_existing(git_local_repo: Pat
     assert relbranch_specifier == {"branch_name": "FIREFOX_100_RELBRANCH"}
 
 
-def test_determine_base_sha_for_push_with_relbranch_missing(git_local_repo: Path):
+def test_determine_base_sha_for_push_with_relbranch_missing(
+    git_local_repo: Path, create_commit: Callable
+):
     """Test determine_base_sha_for_push with a missing relbranch."""
     # Make sure we're on a different branch and make a commit
     subprocess.run(["git", "switch", "-c", "feature"], cwd=git_local_repo)
-    (git_local_repo / "newfile.txt").write_text("feature work")
-    subprocess.run(["git", "add", "."], cwd=git_local_repo)
-    subprocess.run(["git", "commit", "-m", "Feature commit"], cwd=git_local_repo)
+    create_commit("feature work", "Feature commit", "newfile.txt")
 
     base_sha, relbranch_specifier = determine_base_sha_for_push(
         git_local_repo,

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -1,0 +1,53 @@
+import base64
+from pathlib import Path
+from typing import Callable
+from click.testing import CliRunner
+from lando_cli import cli
+import pytest
+from unittest import mock
+
+
+@pytest.fixture
+def mock_get_repo_info(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    mock_fixture = mock.MagicMock()
+    mock_fixture.return_value = {"branch_name": "main", "repo_name": "mock-repo"}
+    monkeypatch.setattr(cli, "get_repo_info", mock_fixture)
+    return mock_fixture
+
+
+@pytest.fixture
+def mock_submit_to_lando(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
+    mock_fixture = mock.MagicMock()
+    monkeypatch.setattr(cli, "submit_to_lando", mock_fixture)
+    return mock_fixture
+
+
+def test_push_commits(
+    git_local_repo: Path,
+    create_commit: Callable,
+    mock_get_repo_info: mock.Mock,
+    mock_submit_to_lando: mock.Mock,
+):
+    commit_message = "New commit to push"
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(git_local_repo):
+        create_commit(commit_message=commit_message)
+        result = runner.invoke(cli.push_commits, ["--yes"])
+
+    assert result.exit_code == 0
+    assert "local branch main" in result.output
+    assert "origin/main as the base commit" in result.output
+    assert commit_message in result.output
+
+    mock_get_repo_info.assert_called_once()
+    mock_submit_to_lando.assert_called_once()
+
+    action = mock_submit_to_lando.call_args.args[2][0]
+    assert action.get("action") == "add-commit-base64"
+
+    content = action.get("content")
+    assert content, "Empty action content"
+
+    decoded = base64.b64decode(content)
+    assert commit_message.encode("utf-8") in decoded

--- a/tests/test_click.py
+++ b/tests/test_click.py
@@ -7,6 +7,20 @@ import pytest
 from unittest import mock
 
 
+@pytest.fixture(autouse=True)
+def mock_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> cli.Config:
+    config_content = """
+            [auth]
+            api_token = "fake_token"
+            user_email = "test@example.com"
+            lando_url = "https://lando.test"
+            """
+    config_file = tmp_path / "lando.toml"
+    config_file.write_text(config_content)
+    monkeypatch.setenv("LANDO_CONFIG_PATH", str(config_file))
+    return cli.Config.load_config()
+
+
 @pytest.fixture
 def mock_get_repo_info(monkeypatch: pytest.MonkeyPatch) -> mock.Mock:
     mock_fixture = mock.MagicMock()


### PR DESCRIPTION
This allows us to handle DOS line terminators. Otherwise, any line ending in patch output is transformed into Unix-style terminators, which later leads to conflicts when trying to apply the patch.

Note: don't merge until mozilla-conduit/lando/pull/374 has been deployed.